### PR TITLE
Blacklist Astral Sorcery blocks

### DIFF
--- a/src/main/java/tschipp/carryon/common/config/Configs.java
+++ b/src/main/java/tschipp/carryon/common/config/Configs.java
@@ -116,6 +116,7 @@ public class Configs {
     					"tconstruct:*",
     					"rustic:*",
     					"botania:*",
+					"astralsorcery:*",
     					"quark:colored_bed_*",
     					"immersiveengineering:*",
     					"embers:block_furnace",


### PR DESCRIPTION
Astral Sorcery has a mechanic called the "starlight network" which misbehaves when tiles are unexpectedly moved or removed. For this reason, AS blocks are also banned from Blood Magic teleposers.