### PR TITLE
Do not parse Mobends configuration every time an entity is rendered

### DIFF
--- a/src/main/java/tschipp/carryon/client/event/RenderEvents.java
+++ b/src/main/java/tschipp/carryon/client/event/RenderEvents.java
@@ -58,6 +58,8 @@ import tschipp.carryon.network.server.SyncKeybindPacket;
 
 public class RenderEvents
 {
+	private boolean obfuscatePresent = Loader.isModLoaded("obfuscate");
+
 	private static boolean initModels;
 
 	/*
@@ -450,7 +452,7 @@ public class RenderEvents
 		if(!CarryOnConfig.settings.renderArms)
 			return;
 		
-		if (handleMobends() && !Loader.isModLoaded("obfuscate"))
+		if (handleMobends() && !obfuscatePresent)
 		{
 			EntityPlayer player = event.getEntityPlayer();
 			EntityPlayerSP clientPlayer = Minecraft.getMinecraft().player;
@@ -547,7 +549,7 @@ public class RenderEvents
 		if(!CarryOnConfig.settings.renderArms)
 			return;
 		
-		if (handleMobends() && !Loader.isModLoaded("obfuscate"))
+		if (handleMobends() && !obfuscatePresent)
 		{
 			EntityPlayer player = event.getEntityPlayer();
 			ItemStack stack = player.getHeldItemMainhand();
@@ -619,16 +621,23 @@ public class RenderEvents
 		arm.isHidden = true;
 	}
 
+	private boolean mobendsPresent = Loader.isModLoaded("mobends");
+
+	private boolean mobendsConfigLoaded = false;
+
+	private boolean mobendsPlayersAnimated = false;
+
 	public boolean handleMobends()
 	{
-		if (Loader.isModLoaded("mobends"))
+		if (mobendsPresent && !mobendsConfigLoaded)
 		{
 			Configuration config = new Configuration(new File(CarryOn.CONFIGURATION_FILE.getPath().substring(0, CarryOn.CONFIGURATION_FILE.getPath().length() - 16), "mobends.cfg"));
 
-			boolean renderPlayer = config.get("animated", "player", true).getBoolean();
-			return !renderPlayer;
+			mobendsPlayersAnimated = config.get("animated", "player", true).getBoolean();
+			mobendsConfigLoaded = true;
 		}
-		return true;
+
+		return !mobendsPlayersAnimated;
 	}
 
 	public static boolean isChest(Block block)


### PR DESCRIPTION
In the current latest release of CarryOn for Minecraft 1.12, the Mobends configuration file is read from disk every time an entity is rendered. This incurs a huge performance penalty and accounts for almost 10% of the frame render time with Mobends installed. This PR fixes the relevant code to only read the configuration file from disk once and to cache the result of `Loader#isModLoaded(String)`.