### PR TITLE
Fixes null being stored to NBT for storeEntityData

### DIFF
--- a/src/main/java/tschipp/carryon/common/item/ItemEntity.java
+++ b/src/main/java/tschipp/carryon/common/item/ItemEntity.java
@@ -70,6 +70,9 @@ public class ItemEntity extends Item
 
 		NBTTagCompound entityData = new NBTTagCompound();
 		entityData = entity.writeToNBT(entityData);
+		
+		if (entityData == null)
+			return false;
 
 		String name = EntityList.getKey(entity).toString();
 


### PR DESCRIPTION
Fixes the following crash/exception
```
[17:06:57] [Server thread/WARN]: [FML]: Java has been asked to exit (code -2)
[17:06:57] [Server thread/WARN]: [FML]: This is an abortive exit and could cause world corruption or other things
[17:06:57] [Server thread/WARN]: [FML]: Exit trace:
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.nbt.NBTTagCompound.handler$checkNullTag$bdj000(NBTTagCompound.java:1158)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.nbt.NBTTagCompound.func_74782_a(NBTTagCompound.java)
[17:06:57] [Server thread/WARN]: [FML]: 	tschipp.carryon.common.item.ItemEntity.storeEntityData(ItemEntity.java:84)
[17:06:57] [Server thread/WARN]: [FML]: 	tschipp.carryon.common.event.ItemEntityEvents.onEntityRightClick(ItemEntityEvents.java:114)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraftforge.fml.common.eventhandler.ASMEventHandler_1235_ItemEntityEvents_onEntityRightClick_EntityInteract.invoke(.dynamic)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:750)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:700)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraftforge.common.ForgeHooks.onInteractEntity(ForgeHooks.java:1116)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.entity.player.EntityPlayer.func_190775_a(EntityPlayer.java:1194)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.network.NetHandlerPlayServer.func_147340_a(NetHandlerPlayServer.java:2691)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.network.play.client.CPacketUseEntity.func_148833_a(SourceFile:69)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.network.play.client.CPacketUseEntity.func_148833_a(SourceFile:13)
[17:06:57] [Server thread/WARN]: [FML]: 	org.spongepowered.common.event.tracking.phase.packet.PacketPhaseUtil.onProcessPacket(PacketPhaseUtil.java:193)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.network.PacketThreadUtil$1.redirect$onProcessPacket$zll000(SourceFile:539)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.network.PacketThreadUtil$1.run(SourceFile:13)
[17:06:57] [Server thread/WARN]: [FML]: 	java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[17:06:57] [Server thread/WARN]: [FML]: 	java.util.concurrent.FutureTask.run(FutureTask.java:266)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.util.Util.func_181617_a(SourceFile:46)
[17:06:57] [Server thread/WARN]: [FML]: 	org.spongepowered.common.SpongeImplHooks.onUtilRunTask(SpongeImplHooks.java:305)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.server.MinecraftServer.redirect$onRun$zjp000(MinecraftServer.java:3965)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:723)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:397)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
[17:06:57] [Server thread/WARN]: [FML]: 	net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
[17:06:57] [Server thread/WARN]: [FML]: 	java.lang.Thread.run(Thread.java:748)
```