### PR TITLE
Config option for picking unbreakable blocks in Survival

### DIFF
--- a/Common/src/main/java/tschipp/carryon/common/carry/PickupHandler.java
+++ b/Common/src/main/java/tschipp/carryon/common/carry/PickupHandler.java
@@ -78,7 +78,7 @@ public class PickupHandler {
         if(!ListHandler.isPermitted(state.getBlock()))
             return false;
 
-        if(state.getDestroySpeed(level, pos) == -1 && !player.isCreative())
+        if(state.getDestroySpeed(level, pos) == -1 && !player.isCreative() && !Constants.COMMON_CONFIG.settings.pickupUnbreakableBlocks)
             return false;
 
         if(blockEntity == null && !Constants.COMMON_CONFIG.settings.pickupAllBlocks)

--- a/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
+++ b/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
@@ -165,6 +165,12 @@ public class CarryConfig {
                     description = "Whether Players can be picked up. Creative players can't be picked up in Survival Mode"
             )
             public boolean pickupPlayers = true;
+
+            @Property(
+                    type = PropertyType.BOOLEAN,
+                    description = "Whether players in Survival Mode can pick up unbreakable blocks. Creative players always can."
+            )
+            public boolean pickupUnbreakableBlocks = false;
         }
 
         @Property(


### PR DESCRIPTION
This was supported in earlier versions of CarryOn, and has some use cases, e.g. moving BetterEnd's eternal pedestals.

Off by default, simply disables the destroySpeed check when picking up a block.

Best combined with a whitelist.