### PR TITLE
Update Configs.java

### DIFF
--- a/src/main/java/tschipp/carryon/common/config/Configs.java
+++ b/src/main/java/tschipp/carryon/common/config/Configs.java
@@ -206,7 +206,9 @@ public class Configs {
     					"integrateddynamics:*",
     					"bloodmagic:*",
     					"rftools:screen",
-						"rftools:creative_screen",
+					"rftools:creative_screen",
+					"movingelevators:elevator_block",
+					"movingelevators:display_block",
     					
     			};
 		


### PR DESCRIPTION
my second time pull requesting this but PLEASE take moving elevators blocks OFF the whitelist, they need to be blacklisted because they crash a server when you pick them up using CarryOn