### PR TITLE
Add minecraft:interaction to entity blacklist

### DIFF
--- a/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
+++ b/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
@@ -283,6 +283,7 @@ public class CarryConfig
 					"minecraft:end_crystal", "minecraft:ender_dragon", "minecraft:ghast",
 					"minecraft:shulker", "minecraft:leash_knot", "minecraft:armor_stand",
 					"minecraft:item_frame", "minecraft:painting", "minecraft:shulker_bullet",
+					"minecraft:interaction",
 					"animania:hamster", "animania:ferret*", "animania:hedgehog*", "animania:cart",
 					"animania:wagon", "mynko:*", "pixelmon:*", "mocreatures:*", "quark:totem", "vehicle:*",
 					"securitycraft:*", "taterzens:npc", "easy_npc:*", "bodiesbodies:dead_body"


### PR DESCRIPTION
Interaction entities are often used and managed by datapacks, and moving them can often break those packs. Picking up an interaction entity can also be confusing to users, since those entities are always invisible.
Closes #659.