### PR TITLE
Forbid "You're in Grave Danger"'s blocks from being picked up

### DIFF
--- a/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
+++ b/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
@@ -284,6 +284,7 @@ public class CarryConfig
 					"modern_industrialization:*_item_pipe",
 					"modern_industrialization:fluid_pipe",
 					"modern_industrialization:*_fluid_pipe",
+					"yigd:*"
 			};
 
 			@Property(


### PR DESCRIPTION
I am proposing this for two reasons:
1. I noticed that [You're in Grave Danger](https://github.com/B1n-ry/Youre-in-grave-danger)'s graves can break if moved with CarryOn, specifically they no longer disappear when opened and the grass colour turns gray.
2. Stealing other players' graves is limited by the mod. Carrying and moving them effectively bypasses that, and so should either not be possible or also be limited by the mod's config.