### PR TITLE
Prevent snow logged blocks from SnowRealMagic from being able to be picked up

### DIFF
--- a/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
+++ b/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
@@ -279,6 +279,7 @@ public class CarryConfig
 					"modern_industrialization:*_item_pipe",
 					"modern_industrialization:fluid_pipe",
 					"modern_industrialization:*_fluid_pipe",
+					"snowrealmagic:*"
 			};
 
 			@Property(


### PR DESCRIPTION
When a block is snow logged (e.g stairs/slabs etc) its able to be picked up by carry on, this is not intended behaviour.