### PR TITLE
Fix issue #757

### DIFF
--- a/NeoForge/src/main/java/tschipp/carryon/events/CommonEvents.java
+++ b/NeoForge/src/main/java/tschipp/carryon/events/CommonEvents.java
@@ -21,6 +21,7 @@
 package tschipp.carryon.events;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -51,6 +52,7 @@ import tschipp.carryon.common.carry.CarryOnData.CarryType;
 import tschipp.carryon.common.carry.CarryOnDataManager;
 import tschipp.carryon.common.carry.PickupHandler;
 import tschipp.carryon.common.carry.PlacementHandler;
+import tschipp.carryon.common.config.CarryConfig;
 import tschipp.carryon.common.scripting.ScriptReloadListener;
 import tschipp.carryon.config.ConfigLoader;
 
@@ -147,9 +149,9 @@ public class CommonEvents
 	}
 
 	@SubscribeEvent
-	public static void onDatapackRegister(AddReloadListenerEvent event)
+	public static void onDatapackRegister(AddServerReloadListenersEvent event)
 	{
-		event.addListener(new ScriptReloadListener());
+		event.addListener(ResourceLocation.fromNamespaceAndPath(Constants.MOD_ID, Constants.MOD_ID), new ScriptReloadListener());
 	}
 
 	@SubscribeEvent

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ fabric_loader_version=0.16.9
 parchment_mappings_fabric=1.21.4:2024.12.29
 
 # Neoforge
-neoforge_version=21.4.47-beta
+neoforge_version=21.4.109-beta
 neoforge_loader_version_range=[4,)
 neogradle.subsystems.parchment.minecraftVersion=1.21.4
 neogradle.subsystems.parchment.mappingsVersion=2024.12.29


### PR DESCRIPTION
Neoforge-beta 21.4.84 introduced a breaking change, which caused CarryOn to fail to load, as described in issue #757. This fixes the issue and causes CarryOn to load correctly again. This also updates the Neoforge version the mod is compiled for to 21.4.109.