### PR TITLE
Fix picking up players

### DIFF
--- a/Common/src/main/java/tschipp/carryon/mixin/EntityMixin.java
+++ b/Common/src/main/java/tschipp/carryon/mixin/EntityMixin.java
@@ -24,6 +24,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Entity.MoveFunction;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
@@ -34,6 +35,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
 import tschipp.carryon.Constants;
 import tschipp.carryon.common.carry.CarryOnData;
 import tschipp.carryon.common.carry.CarryOnData.CarryType;
@@ -67,7 +71,7 @@ public abstract class EntityMixin
 
 	}
 
-	@Inject(method = "getDismountLocationForPassenger(Lnet/minecraft/world/entity/LivingEntity;)Lnet/minecraft/world/phys/Vec3;", at = @At("HEAD"))
+	@Inject(method = "getDismountLocationForPassenger(Lnet/minecraft/world/entity/LivingEntity;)Lnet/minecraft/world/phys/Vec3;", at = @At("HEAD"), cancellable = true)
 	private void onDismountPassenger(LivingEntity living, CallbackInfoReturnable<Vec3> cir)
 	{
 		if((Object)this instanceof Player thisPlayer && living instanceof Player otherPlayer)
@@ -91,6 +95,18 @@ public abstract class EntityMixin
 			if(carry.isCarrying(CarryType.PLAYER)) {
 				this.clampRotation(toUpdate);
 			}
+		}
+	}
+
+	@WrapOperation(
+		method = "startRiding(Lnet/minecraft/world/entity/Entity;Z)Z",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/EntityType;canSerialize()Z")
+	)
+	private boolean allowRidingPlayers(EntityType instance, Operation<Boolean> original) {
+		if(instance == EntityType.PLAYER) {
+			return true;
+		} else {
+			return original.call(instance);
 		}
 	}
 

--- a/Common/src/main/java/tschipp/carryon/networking/clientbound/ClientboundStartRidingPacket.java
+++ b/Common/src/main/java/tschipp/carryon/networking/clientbound/ClientboundStartRidingPacket.java
@@ -47,7 +47,7 @@ public record ClientboundStartRidingPacket(int iden, boolean ride) implements Pa
 		Entity otherPlayer = player.level().getEntity(this.iden);
 		if(otherPlayer != null)
 			if(ride)
-				otherPlayer.startRiding(player);
+				otherPlayer.startRiding(player, true);
 			else
 				otherPlayer.stopRiding();
 	}


### PR DESCRIPTION
Fixes #774
Stacking things onto players still causes some issues so I just advise disabling that in the config by changing `forbiddenStacking` to
``` 
"forbiddenStacking": [
      "minecraft:horse",
      "minecraft:player"
    ]
```

Hopefully this is sufficient.