### PR TITLE
Added uk_ua.json for Ukrainian localization

### DIFF
--- a/Common/src/main/resources/assets/carryon/lang/uk_ua.json
+++ b/Common/src/main/resources/assets/carryon/lang/uk_ua.json
@@ -1,0 +1,16 @@
+{
+  "carryon.category.settings": "Налаштування",
+  "carryon.category.blacklist": "Чорний список",
+  "carryon.category.modeloverrides": "Перевизначення моделей (Розширені)",
+  "carryon.category.custompickupconditions": "Користувацькі умови підбору (Розширені)",
+  "carryon.category.whitelist": "Білий список",
+
+  "carryon.general.modeloverrides.modeloverrides": "Перевизначення моделей",
+  "carryon.general.blacklist.forbiddenentities": "Сутності, які гравець не може підібрати",
+  "carryon.general.blacklist.forbiddentiles": "Блоки, які гравець не може підібрати",
+  "carryon.category.custompickupconditions.custompickupconditionsblocks": "Користувацькі умови підбору блоків",
+  "carryon.category.custompickupconditions.custompickupconditionsentities": "Користувацькі умови підбору сутностей",
+
+  "key.carry.desc": "Нести",
+  "key.carry.category": "Carry On"
+}


### PR DESCRIPTION
**Summary:**
This pull request adds full Ukrainian language support to the CarryOn mod by introducing the uk_ua.json translation file.

**Changes Made:**

- Added uk_ua.json under src/main/resources/assets/carryon/lang/
- Translated all user-facing strings from English to Ukrainian
- Ensured format and keys are consistent with existing localization files