### PR TITLE
Feature: Allow hostile mob pickup customization via data pack scripts.

### DIFF
--- a/Common/src/main/java/tschipp/carryon/common/carry/PickupHandler.java
+++ b/Common/src/main/java/tschipp/carryon/common/carry/PickupHandler.java
@@ -47,6 +47,7 @@ import tschipp.carryon.common.scripting.ScriptManager;
 import tschipp.carryon.networking.clientbound.ClientboundStartRidingPacket;
 import tschipp.carryon.platform.Services;
 
+
 import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.UUID;
@@ -148,7 +149,6 @@ public class PickupHandler {
     }
 
 
-
     public static boolean tryPickupEntity(ServerPlayer player, Entity entity, @Nullable Function<Entity, Boolean> pickupCallback)
     {
         if(!canCarryGeneral(player, entity.position()))
@@ -175,11 +175,44 @@ public class PickupHandler {
                 return false;
         }
 
+        Optional<CarryOnScript> optionalScript =  ScriptManager.inspectEntity(entity);
+
+        // If a script exists, its general conditions (Gamemode, XP, Achievements, etc.) must be satisfied; otherwise, block the entire pickup.
+        if(optionalScript.isPresent())
+        {
+            CarryOnScript script = optionalScript.get();
+            if(!script.fulfillsConditions(player))
+                return false;
+        }
+
         //Non-Creative only guards
         if(!player.isCreative())
         {
-            if(!Constants.COMMON_CONFIG.settings.pickupHostileMobs && entity.getType().getCategory() == MobCategory.MONSTER)
-                return false;
+            boolean scriptAllowsOverride = false;
+
+            if(optionalScript.isPresent())
+            {
+                CarryOnScript script = optionalScript.get();
+
+                Optional<Boolean> canBeCarried = script.scriptPickup().canBeCarried();
+
+                if (canBeCarried.isPresent()) {
+                    boolean scriptResult = canBeCarried.get();
+
+                    if (!scriptResult) {
+                        return false;
+                    }
+
+                    if (scriptResult) {
+                        scriptAllowsOverride = true;
+                    }
+                }
+            }
+
+            if(entity.getType().getCategory() == MobCategory.MONSTER) {
+                if(!Constants.COMMON_CONFIG.settings.pickupHostileMobs && !scriptAllowsOverride)
+                    return false;
+            }
 
             if(Constants.COMMON_CONFIG.settings.maxEntityHeight < entity.getBbHeight() || Constants.COMMON_CONFIG.settings.maxEntityWidth < entity.getBbWidth())
                 return false;
@@ -198,13 +231,9 @@ public class PickupHandler {
 
         CarryOnData carry = CarryOnDataManager.getCarryData(player);
 
-        Optional<CarryOnScript> result =  ScriptManager.inspectEntity(entity);
-        if(result.isPresent())
+        if(optionalScript.isPresent())
         {
-            CarryOnScript script = result.get();
-            if(!script.fulfillsConditions(player))
-                return false;
-
+            CarryOnScript script = optionalScript.get();
             carry.setActiveScript(script);
         }
 
@@ -218,8 +247,8 @@ public class PickupHandler {
             otherPlayer.ejectPassengers();
             otherPlayer.stopRiding();
 
-            if (result.isPresent()) {
-                String cmd = result.get().scriptEffects().commandInit();
+            if (optionalScript.isPresent()) {
+                String cmd = optionalScript.get().scriptEffects().commandInit();
                 if (!cmd.isEmpty())
                     player.getServer().getCommands().performPrefixedCommand(player.getServer().createCommandSourceStack(), "/execute as " + player.getGameProfile().getName() + " run " + cmd);
             }
@@ -240,9 +269,9 @@ public class PickupHandler {
             animal.dropLeash(true, true);
         }
 
-        if(result.isPresent())
+        if(optionalScript.isPresent())
         {
-            String cmd = result.get().scriptEffects().commandInit();
+            String cmd = optionalScript.get().scriptEffects().commandInit();
             if(!cmd.isEmpty())
                 player.getServer().getCommands().performPrefixedCommand(player.getServer().createCommandSourceStack(), "/execute as " + player.getGameProfile().getName() + " run " + cmd);
         }

--- a/Common/src/main/java/tschipp/carryon/common/scripting/CarryOnScript.java
+++ b/Common/src/main/java/tschipp/carryon/common/scripting/CarryOnScript.java
@@ -35,169 +35,186 @@ import tschipp.carryon.common.scripting.Matchables.*;
 import java.util.Optional;
 
 public record CarryOnScript(
-		long priority,
-		ScriptObject scriptObject,
-		ScriptConditions scriptConditions,
-		ScriptRender scriptRender,
-		ScriptEffects scriptEffects)
+        long priority,
+        ScriptObject scriptObject,
+        ScriptConditions scriptConditions,
+        ScriptRender scriptRender,
+        ScriptEffects scriptEffects,
+        ScriptPickup scriptPickup)
 {
 
-	public boolean isValid()
-	{
-		return (isBlock() ^ isEntity()) && (scriptConditions != ScriptConditions.EMPTY || scriptRender != ScriptRender.EMPTY || scriptEffects != ScriptEffects.EMPTY);
-	}
+    public boolean isValid()
+    {
+        return (isBlock() ^ isEntity()) && (scriptConditions != ScriptConditions.EMPTY || scriptRender != ScriptRender.EMPTY || scriptEffects != ScriptEffects.EMPTY);
+    }
 
-	public boolean isBlock()
-	{
-		return scriptObject.block() != ScriptObjectBlock.EMPTY;
-	}
+    public boolean isBlock()
+    {
+        return scriptObject.block() != ScriptObjectBlock.EMPTY;
+    }
 
-	public boolean isEntity()
-	{
-		return scriptObject.entity() != ScriptObjectEntity.EMPTY;
-	}
+    public boolean isEntity()
+    {
+        return scriptObject.entity() != ScriptObjectEntity.EMPTY;
+    }
 
-	public static final Codec<CarryOnScript> CODEC = RecordCodecBuilder.create(instance -> // Given an instance
-			instance.group(
-					Codec.LONG.optionalFieldOf("priority", 0L).forGetter(CarryOnScript::priority),
-					ScriptObject.CODEC.fieldOf("object").forGetter(CarryOnScript::scriptObject),
-					ScriptConditions.CODEC.optionalFieldOf("conditions", ScriptConditions.EMPTY).forGetter(CarryOnScript::scriptConditions),
-					ScriptRender.CODEC.optionalFieldOf("render", ScriptRender.EMPTY).forGetter(CarryOnScript::scriptRender),
-					ScriptEffects.CODEC.optionalFieldOf("effects", ScriptEffects.EMPTY).forGetter(CarryOnScript::scriptEffects)
-			).apply(instance, CarryOnScript::new)
-	);
+    public static final Codec<CarryOnScript> CODEC = RecordCodecBuilder.create(instance -> // Given an instance
+            instance.group(
+                    Codec.LONG.optionalFieldOf("priority", 0L).forGetter(CarryOnScript::priority),
+                    ScriptObject.CODEC.fieldOf("object").forGetter(CarryOnScript::scriptObject),
+                    ScriptConditions.CODEC.optionalFieldOf("conditions", ScriptConditions.EMPTY).forGetter(CarryOnScript::scriptConditions),
+                    ScriptRender.CODEC.optionalFieldOf("render", ScriptRender.EMPTY).forGetter(CarryOnScript::scriptRender),
+                    ScriptEffects.CODEC.optionalFieldOf("effects", ScriptEffects.EMPTY).forGetter(CarryOnScript::scriptEffects),
+                    ScriptPickup.CODEC.optionalFieldOf("pickup", ScriptPickup.EMPTY).forGetter(CarryOnScript::scriptPickup)
+            ).apply(instance, CarryOnScript::new)
+    );
 
-	public boolean fulfillsConditions(ServerPlayer player)
-	{
-		ScriptConditions cond = this.scriptConditions();
+    public boolean fulfillsConditions(ServerPlayer player)
+    {
+        ScriptConditions cond = this.scriptConditions();
 
-		boolean achievement = cond.conditionAchievement.matches(player);
-		boolean gamemode = cond.conditionGamemode.matches(player.gameMode.getGameModeForPlayer().getId());
-		boolean gamestage = cond.conditionGamestage.matches(player);
-		boolean position = cond.conditionPosition.matches(player);
-		boolean xp = cond.conditionXp.matches(player.experienceLevel);
-		boolean scoreboard = cond.conditionScoreboard.matches(player);
-		boolean effects = cond.conditionEffects.matches(player);
+        if (cond.equals(ScriptConditions.EMPTY)) {
+            return true;
+        }
 
-		return achievement && gamemode && gamestage && position && xp && scoreboard && effects;
-	}
+        boolean achievement = cond.conditionAchievement.matches(player);
+        boolean gamemode = cond.conditionGamemode.matches(player.gameMode.getGameModeForPlayer().getId());
+        boolean gamestage = cond.conditionGamestage.matches(player);
+        boolean position = cond.conditionPosition.matches(player);
+        boolean xp = cond.conditionXp.matches(player.experienceLevel);
+        boolean scoreboard = cond.conditionScoreboard.matches(player);
+        boolean effects = cond.conditionEffects.matches(player);
+
+        return achievement && gamemode && gamestage && position && xp && scoreboard && effects;
+    }
 
 
-	public record ScriptObject(ScriptObjectBlock block, ScriptObjectEntity entity)
-	{
-		public static final Codec<ScriptObject> CODEC = RecordCodecBuilder.create(instance ->
-				instance.group(
-						ScriptObjectBlock.CODEC.optionalFieldOf("block", ScriptObjectBlock.EMPTY).forGetter(ScriptObject::block),
-						ScriptObjectEntity.CODEC.optionalFieldOf("entity", ScriptObjectEntity.EMPTY).forGetter(ScriptObject::entity)
-						).apply(instance, ScriptObject::new)
-		);
+    public record ScriptObject(ScriptObjectBlock block, ScriptObjectEntity entity)
+    {
+        public static final Codec<ScriptObject> CODEC = RecordCodecBuilder.create(instance ->
+                instance.group(
+                        ScriptObjectBlock.CODEC.optionalFieldOf("block", ScriptObjectBlock.EMPTY).forGetter(ScriptObject::block),
+                        ScriptObjectEntity.CODEC.optionalFieldOf("entity", ScriptObjectEntity.EMPTY).forGetter(ScriptObject::entity)
+                ).apply(instance, ScriptObject::new)
+        );
 
-		public record ScriptObjectBlock(
-				Optional<ResourceKey<Block>> typeNameBlock,
-				NumberBoundCondition typeHardness,
-				NumberBoundCondition typeResistance,
-				NBTCondition typeBlockTag
-				){
-			public static final ScriptObjectBlock EMPTY = new ScriptObjectBlock(Optional.empty(), NumberBoundCondition.NONE, NumberBoundCondition.NONE, NBTCondition.NONE);
+        public record ScriptObjectBlock(
+                Optional<ResourceKey<Block>> typeNameBlock,
+                NumberBoundCondition typeHardness,
+                NumberBoundCondition typeResistance,
+                NBTCondition typeBlockTag
+        ){
+            public static final ScriptObjectBlock EMPTY = new ScriptObjectBlock(Optional.empty(), NumberBoundCondition.NONE, NumberBoundCondition.NONE, NBTCondition.NONE);
 
-			public static final Codec<ScriptObjectBlock> CODEC = RecordCodecBuilder.create(instance ->
-					instance.group(
-							ResourceKey.codec(Registries.BLOCK).optionalFieldOf("name").forGetter(ScriptObjectBlock::typeNameBlock),
-							NumberBoundCondition.CODEC.optionalFieldOf("hardness", NumberBoundCondition.NONE).forGetter(ScriptObjectBlock::typeHardness),
-							NumberBoundCondition.CODEC.optionalFieldOf("resistance", NumberBoundCondition.NONE).forGetter(ScriptObjectBlock::typeResistance),
-							NBTCondition.CODEC.optionalFieldOf("nbt", NBTCondition.NONE).forGetter(ScriptObjectBlock::typeBlockTag)
-							).apply(instance, ScriptObjectBlock::new)
-			);
-		}
+            public static final Codec<ScriptObjectBlock> CODEC = RecordCodecBuilder.create(instance ->
+                    instance.group(
+                            ResourceKey.codec(Registries.BLOCK).optionalFieldOf("name").forGetter(ScriptObjectBlock::typeNameBlock),
+                            NumberBoundCondition.CODEC.optionalFieldOf("hardness", NumberBoundCondition.NONE).forGetter(ScriptObjectBlock::typeHardness),
+                            NumberBoundCondition.CODEC.optionalFieldOf("resistance", NumberBoundCondition.NONE).forGetter(ScriptObjectBlock::typeResistance),
+                            NBTCondition.CODEC.optionalFieldOf("nbt", NBTCondition.NONE).forGetter(ScriptObjectBlock::typeBlockTag)
+                    ).apply(instance, ScriptObjectBlock::new)
+            );
+        }
 
-		public record ScriptObjectEntity(
-				Optional<ResourceKey<EntityType<?>>> typeNameEntity,
-				NumberBoundCondition typeHealth,
-				NumberBoundCondition typeHeight,
-				NumberBoundCondition typeWidth,
-				NBTCondition typeEntityTag
-				){
-			public static final ScriptObjectEntity EMPTY = new ScriptObjectEntity(Optional.empty(), NumberBoundCondition.NONE, NumberBoundCondition.NONE, NumberBoundCondition.NONE, NBTCondition.NONE);
+        public record ScriptObjectEntity(
+                Optional<ResourceKey<EntityType<?>>> typeNameEntity,
+                NumberBoundCondition typeHealth,
+                NumberBoundCondition typeHeight,
+                NumberBoundCondition typeWidth,
+                NBTCondition typeEntityTag
+        ){
+            public static final ScriptObjectEntity EMPTY = new ScriptObjectEntity(Optional.empty(), NumberBoundCondition.NONE, NumberBoundCondition.NONE, NumberBoundCondition.NONE, NBTCondition.NONE);
 
-			public static final Codec<ScriptObjectEntity> CODEC = RecordCodecBuilder.create(instance ->
-					instance.group(
-							ResourceKey.codec(Registries.ENTITY_TYPE).optionalFieldOf("name").forGetter(ScriptObjectEntity::typeNameEntity),
-							NumberBoundCondition.CODEC.optionalFieldOf("health", NumberBoundCondition.NONE).forGetter(ScriptObjectEntity::typeHealth),
-							NumberBoundCondition.CODEC.optionalFieldOf("height", NumberBoundCondition.NONE).forGetter(ScriptObjectEntity::typeHeight),
-							NumberBoundCondition.CODEC.optionalFieldOf("width", NumberBoundCondition.NONE).forGetter(ScriptObjectEntity::typeWidth),
-							NBTCondition.CODEC.optionalFieldOf("nbt", NBTCondition.NONE).forGetter(ScriptObjectEntity::typeEntityTag)
-					).apply(instance, ScriptObjectEntity::new)
-			);
-		}
-	}
+            public static final Codec<ScriptObjectEntity> CODEC = RecordCodecBuilder.create(instance ->
+                    instance.group(
+                            ResourceKey.codec(Registries.ENTITY_TYPE).optionalFieldOf("name").forGetter(ScriptObjectEntity::typeNameEntity),
+                            NumberBoundCondition.CODEC.optionalFieldOf("health", NumberBoundCondition.NONE).forGetter(ScriptObjectEntity::typeHealth),
+                            NumberBoundCondition.CODEC.optionalFieldOf("height", NumberBoundCondition.NONE).forGetter(ScriptObjectEntity::typeHeight),
+                            NumberBoundCondition.CODEC.optionalFieldOf("width", NumberBoundCondition.NONE).forGetter(ScriptObjectEntity::typeWidth),
+                            NBTCondition.CODEC.optionalFieldOf("nbt", NBTCondition.NONE).forGetter(ScriptObjectEntity::typeEntityTag)
+                    ).apply(instance, ScriptObjectEntity::new)
+            );
+        }
+    }
 
-	public record ScriptConditions(
-			GamestageCondition conditionGamestage,
-			AdvancementCondition conditionAchievement,
-			NumberBoundCondition conditionXp,
-			NumberBoundCondition conditionGamemode,
-			ScoreboardCondition conditionScoreboard,
-			PositionCondition conditionPosition,
-			EffectsCondition conditionEffects
-	){
-		public static final ScriptConditions EMPTY = new ScriptConditions(GamestageCondition.NONE, AdvancementCondition.NONE, NumberBoundCondition.NONE, NumberBoundCondition.NONE, ScoreboardCondition.NONE, PositionCondition.NONE, EffectsCondition.NONE);
+    public record ScriptConditions(
+            GamestageCondition conditionGamestage,
+            AdvancementCondition conditionAchievement,
+            NumberBoundCondition conditionXp,
+            NumberBoundCondition conditionGamemode,
+            ScoreboardCondition conditionScoreboard,
+            PositionCondition conditionPosition,
+            EffectsCondition conditionEffects
+    ){
+        public static final ScriptConditions EMPTY = new ScriptConditions(GamestageCondition.NONE, AdvancementCondition.NONE, NumberBoundCondition.NONE, NumberBoundCondition.NONE, ScoreboardCondition.NONE, PositionCondition.NONE, EffectsCondition.NONE);
 
-		public static final Codec<ScriptConditions> CODEC = RecordCodecBuilder.create(instance ->
-				instance.group(
-					GamestageCondition.CODEC.optionalFieldOf("gamestage", GamestageCondition.NONE).forGetter(ScriptConditions::conditionGamestage),
-					AdvancementCondition.CODEC.optionalFieldOf("advancement", AdvancementCondition.NONE).forGetter(ScriptConditions::conditionAchievement),
-					NumberBoundCondition.CODEC.optionalFieldOf("xp", NumberBoundCondition.NONE).forGetter(ScriptConditions::conditionXp),
-					NumberBoundCondition.CODEC.optionalFieldOf("gamemode", NumberBoundCondition.NONE).forGetter(ScriptConditions::conditionGamemode),
-					ScoreboardCondition.CODEC.optionalFieldOf("scoreboard", ScoreboardCondition.NONE).forGetter(ScriptConditions::conditionScoreboard),
-					PositionCondition.CODEC.optionalFieldOf("position", PositionCondition.NONE).forGetter(ScriptConditions::conditionPosition),
-					EffectsCondition.CODEC.optionalFieldOf("effects", EffectsCondition.NONE).forGetter(ScriptConditions::conditionEffects)
-				).apply(instance, ScriptConditions::new)
-		);
-	}
+        public static final Codec<ScriptConditions> CODEC = RecordCodecBuilder.create(instance ->
+                instance.group(
+                        GamestageCondition.CODEC.optionalFieldOf("gamestage", GamestageCondition.NONE).forGetter(ScriptConditions::conditionGamestage),
+                        AdvancementCondition.CODEC.optionalFieldOf("advancement", AdvancementCondition.NONE).forGetter(ScriptConditions::conditionAchievement),
+                        NumberBoundCondition.CODEC.optionalFieldOf("xp", NumberBoundCondition.NONE).forGetter(ScriptConditions::conditionXp),
+                        NumberBoundCondition.CODEC.optionalFieldOf("gamemode", NumberBoundCondition.NONE).forGetter(ScriptConditions::conditionGamemode),
+                        ScoreboardCondition.CODEC.optionalFieldOf("scoreboard", ScoreboardCondition.NONE).forGetter(ScriptConditions::conditionScoreboard),
+                        PositionCondition.CODEC.optionalFieldOf("position", PositionCondition.NONE).forGetter(ScriptConditions::conditionPosition),
+                        EffectsCondition.CODEC.optionalFieldOf("effects", EffectsCondition.NONE).forGetter(ScriptConditions::conditionEffects)
+                ).apply(instance, ScriptConditions::new)
+        );
+    }
 
-	public record ScriptRender(
-			Optional<ResourceKey<Block>> renderNameBlock,
-			Optional<ResourceKey<EntityType<?>>> renderNameEntity,
-			Optional<CompoundTag> renderNBT,
-			OptionalVec3 renderTranslation,
-			OptionalVec3 renderRotation,
-			OptionalVec3 renderscale,
-			OptionalVec3 renderRotationLeftArm,
-			OptionalVec3 renderRotationRightArm,
-			boolean renderLeftArm,
-			boolean renderRightArm
-	){
-		public static final ScriptRender EMPTY = new ScriptRender(Optional.empty(), Optional.empty(), Optional.empty(), OptionalVec3.NONE, OptionalVec3.NONE, OptionalVec3.NONE, OptionalVec3.NONE, OptionalVec3.NONE, true, true);
+    public record ScriptRender(
+            Optional<ResourceKey<Block>> renderNameBlock,
+            Optional<ResourceKey<EntityType<?>>> renderNameEntity,
+            Optional<CompoundTag> renderNBT,
+            OptionalVec3 renderTranslation,
+            OptionalVec3 renderRotation,
+            OptionalVec3 renderscale,
+            OptionalVec3 renderRotationLeftArm,
+            OptionalVec3 renderRotationRightArm,
+            boolean renderLeftArm,
+            boolean renderRightArm
+    ){
+        public static final ScriptRender EMPTY = new ScriptRender(Optional.empty(), Optional.empty(), Optional.empty(), OptionalVec3.NONE, OptionalVec3.NONE, OptionalVec3.NONE, OptionalVec3.NONE, OptionalVec3.NONE, true, true);
 
-		public static final Codec<ScriptRender> CODEC = RecordCodecBuilder.create(instance ->
-				instance.group(
-						ResourceKey.codec(Registries.BLOCK).optionalFieldOf("name_block").forGetter(ScriptRender::renderNameBlock),
-						ResourceKey.codec(Registries.ENTITY_TYPE).optionalFieldOf("name_entity").forGetter(ScriptRender::renderNameEntity),
-						CompoundTag.CODEC.optionalFieldOf("nbt").forGetter(ScriptRender::renderNBT),
-						OptionalVec3.CODEC.optionalFieldOf("translation", OptionalVec3.NONE).forGetter(ScriptRender::renderTranslation),
-						OptionalVec3.CODEC.optionalFieldOf("rotation", OptionalVec3.NONE).forGetter(ScriptRender::renderRotation),
-						OptionalVec3.CODEC.optionalFieldOf("scale", OptionalVec3.NONE).forGetter(ScriptRender::renderscale),
-						OptionalVec3.CODEC.optionalFieldOf("rotation_left_arm", OptionalVec3.NONE).forGetter(ScriptRender::renderRotationLeftArm),
-						OptionalVec3.CODEC.optionalFieldOf("rotation_right_arm", OptionalVec3.NONE).forGetter(ScriptRender::renderRotationRightArm),
-						Codec.BOOL.optionalFieldOf("render_left_arm", true).forGetter(ScriptRender::renderLeftArm),
-						Codec.BOOL.optionalFieldOf("render_right_arm", true).forGetter(ScriptRender::renderRightArm)
-						).apply(instance, ScriptRender::new)
-		);
-	}
+        public static final Codec<ScriptRender> CODEC = RecordCodecBuilder.create(instance ->
+                instance.group(
+                        ResourceKey.codec(Registries.BLOCK).optionalFieldOf("name_block").forGetter(ScriptRender::renderNameBlock),
+                        ResourceKey.codec(Registries.ENTITY_TYPE).optionalFieldOf("name_entity").forGetter(ScriptRender::renderNameEntity),
+                        CompoundTag.CODEC.optionalFieldOf("nbt").forGetter(ScriptRender::renderNBT),
+                        OptionalVec3.CODEC.optionalFieldOf("translation", OptionalVec3.NONE).forGetter(ScriptRender::renderTranslation),
+                        OptionalVec3.CODEC.optionalFieldOf("rotation", OptionalVec3.NONE).forGetter(ScriptRender::renderRotation),
+                        OptionalVec3.CODEC.optionalFieldOf("scale", OptionalVec3.NONE).forGetter(ScriptRender::renderscale),
+                        OptionalVec3.CODEC.optionalFieldOf("rotation_left_arm", OptionalVec3.NONE).forGetter(ScriptRender::renderRotationLeftArm),
+                        OptionalVec3.CODEC.optionalFieldOf("rotation_right_arm", OptionalVec3.NONE).forGetter(ScriptRender::renderRotationRightArm),
+                        Codec.BOOL.optionalFieldOf("render_left_arm", true).forGetter(ScriptRender::renderLeftArm),
+                        Codec.BOOL.optionalFieldOf("render_right_arm", true).forGetter(ScriptRender::renderRightArm)
+                ).apply(instance, ScriptRender::new)
+        );
+    }
 
-	public record ScriptEffects(
-			String commandInit,
-			String commandLoop,
-			String commandPlace
-	){
-		public static final ScriptEffects EMPTY = new ScriptEffects("", "", "");
+    public record ScriptEffects(
+            String commandInit,
+            String commandLoop,
+            String commandPlace
+    ){
+        public static final ScriptEffects EMPTY = new ScriptEffects("", "", "");
 
-		public static final Codec<ScriptEffects> CODEC = RecordCodecBuilder.create(instance ->
-				instance.group(
-						Codec.STRING.optionalFieldOf("commandPickup", "").forGetter(ScriptEffects::commandInit),
-						Codec.STRING.optionalFieldOf("commandLoop", "").forGetter(ScriptEffects::commandLoop),
-						Codec.STRING.optionalFieldOf("commandPlace", "").forGetter(ScriptEffects::commandPlace)
-						).apply(instance, ScriptEffects::new)
-		);
-	}
+        public static final Codec<ScriptEffects> CODEC = RecordCodecBuilder.create(instance ->
+                instance.group(
+                        Codec.STRING.optionalFieldOf("commandPickup", "").forGetter(ScriptEffects::commandInit),
+                        Codec.STRING.optionalFieldOf("commandLoop", "").forGetter(ScriptEffects::commandLoop),
+                        Codec.STRING.optionalFieldOf("commandPlace", "").forGetter(ScriptEffects::commandPlace)
+                ).apply(instance, ScriptEffects::new)
+        );
+    }
+
+    // Custom PickupRule in scripts of datapack.
+    public record ScriptPickup(Optional<Boolean> canBeCarried) {
+        public static final ScriptPickup EMPTY = new ScriptPickup(Optional.empty());
+
+        public static final Codec<ScriptPickup> CODEC = RecordCodecBuilder.create(instance ->
+                instance.group(
+                        Codec.BOOL.optionalFieldOf("canBeCarried").forGetter(ScriptPickup::canBeCarried)
+                ).apply(instance, ScriptPickup::new)
+        );
+    }
 }

--- a/Common/src/main/java/tschipp/carryon/common/scripting/ScriptManager.java
+++ b/Common/src/main/java/tschipp/carryon/common/scripting/ScriptManager.java
@@ -39,72 +39,72 @@ import java.util.Optional;
 
 public class ScriptManager
 {
-	public static final List<CarryOnScript> SCRIPTS = new ArrayList<>();
+    public static final List<CarryOnScript> SCRIPTS = new ArrayList<>();
 
-	public static Optional<CarryOnScript> inspectBlock(BlockState state, Level level, BlockPos pos, @Nullable CompoundTag tag)
-	{
-		if (!Constants.COMMON_CONFIG.settings.useScripts)
-			return Optional.empty();
+    public static Optional<CarryOnScript> inspectBlock(BlockState state, Level level, BlockPos pos, @Nullable CompoundTag tag)
+    {
+        if (!Constants.COMMON_CONFIG.settings.useScripts)
+            return Optional.empty();
 
-		Block block = state.getBlock();
-		float hardness = state.getDestroySpeed(level, pos);
-		float resistance = block.getExplosionResistance();
+        Block block = state.getBlock();
+        float hardness = state.getDestroySpeed(level, pos);
+        float resistance = block.getExplosionResistance();
 
-		for (CarryOnScript script : SCRIPTS)
-		{
-			if (script.isBlock() && matchesAll(script, block, hardness, resistance, tag))
-				return Optional.of(script);
-		}
+        for (CarryOnScript script : SCRIPTS)
+        {
+            if (script.isBlock() && matchesAll(script, block, hardness, resistance, tag))
+                return Optional.of(script);
+        }
 
-		return Optional.empty();
-	}
+        return Optional.empty();
+    }
 
-	public static Optional<CarryOnScript> inspectEntity(Entity entity)
-	{
-		if (!Constants.COMMON_CONFIG.settings.useScripts)
-			return Optional.empty();
+    public static Optional<CarryOnScript> inspectEntity(Entity entity)
+    {
+        if (!Constants.COMMON_CONFIG.settings.useScripts)
+            return Optional.empty();
 
-		float height = entity.getBbHeight();
-		float width = entity.getBbWidth();
-		float health = entity instanceof LivingEntity ? ((LivingEntity) entity).getHealth() : 0.0f;
-		CompoundTag tag = new CompoundTag();
-		entity.save(tag);
+        float height = entity.getBbHeight();
+        float width = entity.getBbWidth();
+        float health = entity instanceof LivingEntity ? ((LivingEntity) entity).getHealth() : 0.0f;
+        CompoundTag tag = new CompoundTag();
+        entity.save(tag);
 
-		for (CarryOnScript script : SCRIPTS)
-		{
-			if (script.isEntity() && matchesAll(script, entity, height, width, health, tag))
-				return Optional.of(script);
-		}
+        for (CarryOnScript script : SCRIPTS)
+        {
+            if (script.isEntity() && matchesAll(script, entity, height, width, health, tag))
+                return Optional.of(script);
+        }
 
-		return Optional.empty();
-	}
+        return Optional.empty();
+    }
 
-	private static boolean matchesAll(CarryOnScript script, Entity entity, float height, float width, float health, CompoundTag tag)
-	{
-		ScriptObjectEntity scEntity = script.scriptObject().entity();
+    private static boolean matchesAll(CarryOnScript script, Entity entity, float height, float width, float health, CompoundTag tag)
+    {
+        ScriptObjectEntity scEntity = script.scriptObject().entity();
 
-		boolean matchname = true;
-		if(scEntity.typeNameEntity().isPresent())
-			matchname = entity.getType().equals(BuiltInRegistries.ENTITY_TYPE.get(scEntity.typeNameEntity().get()));
-		boolean matchheight = scEntity.typeHeight().matches(height);
-		boolean matchwidth = scEntity.typeWidth().matches(width);
-		boolean matchhealth = scEntity.typeHealth().matches(health);
-		boolean matchnbt = scEntity.typeEntityTag().matches(tag);
+        boolean matchname = true;
+        if(scEntity.typeNameEntity().isPresent())
+            matchname = entity.getType().equals(BuiltInRegistries.ENTITY_TYPE.get(scEntity.typeNameEntity().get()));
+        boolean matchheight = scEntity.typeHeight().matches(height);
+        boolean matchwidth = scEntity.typeWidth().matches(width);
+        boolean matchhealth = scEntity.typeHealth().matches(health);
+        boolean matchnbt = scEntity.typeEntityTag().matches(tag);
 
-		return matchname && matchheight && matchwidth && matchhealth && matchnbt;
-	}
+        return matchname && matchheight && matchwidth && matchhealth && matchnbt;
+    }
 
-	private static boolean matchesAll(CarryOnScript script, Block block, float hardness, float resistance, CompoundTag nbt)
-	{
-		ScriptObjectBlock scBlock = script.scriptObject().block();
+    private static boolean matchesAll(CarryOnScript script, Block block, float hardness, float resistance, CompoundTag nbt)
+    {
+        ScriptObjectBlock scBlock = script.scriptObject().block();
 
-		boolean matchblock = true;
-		if(scBlock.typeNameBlock().isPresent())
-			matchblock = block == BuiltInRegistries.BLOCK.get(scBlock.typeNameBlock().get());
-		boolean matchnbt = scBlock.typeBlockTag().matches(nbt);
-		boolean matchhardness = scBlock.typeHardness().matches(hardness);
-		boolean matchresistance = scBlock.typeResistance().matches(resistance);
+        boolean matchblock = true;
+        if(scBlock.typeNameBlock().isPresent())
+            matchblock = block == BuiltInRegistries.BLOCK.get(scBlock.typeNameBlock().get());
+        boolean matchnbt = scBlock.typeBlockTag().matches(nbt);
+        boolean matchhardness = scBlock.typeHardness().matches(hardness);
+        boolean matchresistance = scBlock.typeResistance().matches(resistance);
 
-		return matchnbt && matchblock && matchhardness && matchresistance;
-	}
+        return matchnbt && matchblock && matchhardness && matchresistance;
+    }
 }


### PR DESCRIPTION
This introduces the 'pickup.canBeCarried' optional boolean field to CarryOnScript, enabling users to explicitly allow or disallow carrying specific hostile mobs, overriding the global configuration setting.

Fixes:
- Moves pickup logic into the !isCreative guard to respect Creative Mode permissions.
- Corrects Codec parsing by nesting 'canBeCarried' under 'pickup'.
- Ensures empty conditions default to true.