### PR TITLE
Fix distance check for physics mods and add Create Simulated mods to blacklist

### DIFF
--- a/Common/src/main/java/tschipp/carryon/common/carry/PickupHandler.java
+++ b/Common/src/main/java/tschipp/carryon/common/carry/PickupHandler.java
@@ -64,7 +64,8 @@ public class PickupHandler {
         if(!player.getMainHandItem().isEmpty() || !player.getOffhandItem().isEmpty())
             return false;
 
-        if(player.position().distanceTo(pos) > Constants.COMMON_CONFIG.settings.maxDistance)
+        double maxDistance = Constants.COMMON_CONFIG.settings.maxDistance;
+        if(player.distanceToSqr(pos) > maxDistance * maxDistance)
             return false;
 
         CarryOnData carry = CarryOnDataManager.getCarryData(player);

--- a/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
+++ b/Common/src/main/java/tschipp/carryon/common/config/CarryConfig.java
@@ -302,7 +302,8 @@ public class CarryConfig
 					"animania:hamster", "animania:ferret*", "animania:hedgehog*", "animania:cart",
 					"animania:wagon", "mynko:*", "pixelmon:*", "mocreatures:*", "quark:totem", "vehicle:*",
 					"securitycraft:*", "taterzens:npc", "easy_npc:*", "bodiesbodies:dead_body", "littletiles:*",
-					"connectiblechains:*", "cobblemon:*", "create:*", "swem:*", "toms_mobs:*"
+					"connectiblechains:*", "cobblemon:*", "create:*", "swem:*", "toms_mobs:*",
+					"simulated:*", "aeronautics:*", "offroad:*"
 			};
 
 			@Property(


### PR DESCRIPTION
Closes #776.

This changes the distance check in `PickupHandler` to use the entity function `distanceToSqr` rather than the Vec3-to-Vec3 function `distanceTo`. This is because the former is patched by Valkyrien Skies ([here](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/blob/4f2a0e4004d3b09662c8d6ec15d41db296eff31a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/distance_replace/MixinEntity.java#L26)) and Sable / Create Aeronautics ([here](https://github.com/ryanhcode/sable/blob/7069eea3f234317e61f697ceef2141c4fb944ce2/common/src/main/java/dev/ryanhcode/sable/mixin/interaction_distance/EntityMixin.java#L50)) to take into account their physics entities (called "ships" and "sub-levels" respectively).

I also added the Create Simulated family of mods to `forbiddenTiles` in a separate commit. That is Simulated, Aeronautics, Offroad, which are all included in the single mod "Create Aeronautics" that you can download. (At time of writing.)

I tried to build the mod to ensure I didn't sneak in a syntax error or so, but (as usual?) the build failed in ways I can't debug. Apologies for being unable to test my changes. I can however confirm the change itself is sound, as [my mixin mod](https://modrinth.com/mod/carryon-aeronautics-compat) works.

I targeted the 1.21.11 branch since it appears to be the active development branch, however I recommend this change be backported to at least 1.21.1 (which is the version Create Aeronautics currently targets) and 1.20.1 (version targeted by Valkyrien Skies), so players who are playing those mods benefit from the changes.