### PR TITLE
Fix NPE in CarryOnDataSyncHandler causing server-wide disconnects on player death

### DIFF
--- a/NeoForge/src/main/java/tschipp/carryon/carry/CarryOnDataSyncHandler.java
+++ b/NeoForge/src/main/java/tschipp/carryon/carry/CarryOnDataSyncHandler.java
@@ -24,7 +24,11 @@ public class CarryOnDataSyncHandler implements AttachmentSyncHandler<CarryOnData
         // the isAlive check avoids us syncing attachment data about dead players. Which causes a disconnect
         // player.tickCount <= 0 avoids us syncing attachment data about players the instant they spawn. 
         // Which also causes a disconnect as the player entity may not be synced yet.
+        // The same checks apply to the recipient: syncing to a dead or just-spawned player
+        // causes a NPE in the RegistryFriendlyByteBuf internals (wrapped == null), kicking all players.
         if (to.connection == null || !player.isAlive() || player.tickCount <= 0 || player.isRemoved())
+            return false;
+        if (!to.isAlive() || to.isRemoved() || to.tickCount <= 0)
             return false;
         return AttachmentSyncHandler.super.sendToPlayer(holder, to);
     }


### PR DESCRIPTION
## Problem

When any player dies, NeoForge triggers an attachment sync for all players to all observers. `sendToPlayer()` already guards against syncing data *from* dead or just-spawned players, but not *to* players in those states.

When the recipient (`to`) is dying or respawning, the `RegistryFriendlyByteBuf` internals have a null `ObjectArrayList` (`wrapped == null`), causing:

```
Failed encoding custom payload carryon:sync_carry_data:
NullPointerException: Cannot invoke "ObjectArrayList.get(int)"
because "this.wrapped" is null
```

This crashes the packet encoder and **kicks every connected player simultaneously**. Reliably reproducible: any player death while others are online. Reported in #945, #961, #972.

## Fix

Apply the same liveness guards to the recipient (`to`) that already exist for the holder (`player`) — one extra `if` block, mirroring the existing logic and its comments:

```java
if (!to.isAlive() || to.isRemoved() || to.tickCount <= 0)
    return false;
```

## Testing

Reproduced on a NeoForge 21.1.234 server with multiple players online. Before the fix: any player death causes a server-wide disconnect. The fix has not been tested yet,  I generated the pr with claude code, I hope that this can help in any way,

Feel free to leave a comment or review to let me know if it's ok or not.

Note: the `1.21.1` branch already addresses this differently by commenting out the sync handler entirely. This PR brings an equivalent fix to `1.21.11` (and by extension `1.21.8`/`1.21.9`) where the sync handler is still active.